### PR TITLE
I85 added percent score to eval list

### DIFF
--- a/src/app/core/revisions/revisions.component.html
+++ b/src/app/core/revisions/revisions.component.html
@@ -4,6 +4,12 @@
     <section class="component-content">
         <h4>Revision History</h4>
         <div>
+            <h5>version 1.4.1</h5>
+            <ul>
+                <li>Added percent score to student evaluation list</li>
+            </ul>
+        </div>
+        <div>
             <h5>version 1.4</h5>
             <ul>
                 <li>Inactive students don't display check-in/out button</li>

--- a/src/app/feat/eval/evaluation-student-list/evaluation-student-list.component.html
+++ b/src/app/feat/eval/evaluation-student-list/evaluation-student-list.component.html
@@ -10,6 +10,7 @@
                 <td class="sortable"><a (click)="sort('id')">Id</a></td>
                 <td class="sortable"><a (click)="sort('description')">Description</a></td>
                 <td>Questions</td>
+                <td>Score</td>
                 <td>Actions</td>
             </tr>
         </thead>
@@ -18,6 +19,8 @@
                 <td>{{ e.id }}</td>
                 <td>{{ e.description }}</td>
                 <td>{{ e.questions.length }}</td>
+                <td *ngIf="!e.isDone"></td>
+                <td *ngIf="e.isDone">{{e.pointsScored / e.pointsAvailable | percent}}</td>
                 <td *ngIf="!e.isDone">
                     <a routerLink="/evals/take/{{e.id}}">Take</a> 
                 </td>


### PR DESCRIPTION
Previously, after a student took an eval/assessment, no score displayed in the list page. This adds that percent score after the eval/assessment is taken